### PR TITLE
fix: Readme change flag -p to -e

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ resource "profile" "amazon" {
 }
 ```
 
-Note: You can switch between environments by passing `-p default` or `-p prod`
+Note: You can switch between environments by passing `-e default` or `-e prod`
 
 ### Adding command aliases
 


### PR DESCRIPTION
To choose between environments, `-e` or `--env` flag is the correct one, but it mentioned `-p` in the Readme file